### PR TITLE
Fix typo: Rename centerLatidude to centerLatitude

### DIFF
--- a/review.md
+++ b/review.md
@@ -19,7 +19,7 @@
 **Code Quality:**
 - `TemplateLiveProgram.kt:324`: Complex, monolithic main function (300+ lines) - needs refactoring
 - Multiple hardcoded magic numbers throughout (`SPEED_UP_FACTOR = 20`, `ELEVATION_SMOOTHING = 0.5`)
-- Inconsistent naming: `centerLatidude` should be `centerLatitude` in `PixelsTransformation.kt:142`
+- ~~Inconsistent naming: `centerLatidude` should be `centerLatitude` in `PixelsTransformation.kt:142`~~ ✅ Fixed
 - Missing input validation in coordinate transformation functions
 
 **Error Handling:**
@@ -42,7 +42,7 @@
 1. **Refactor TemplateLiveProgram**: Extract rendering logic into separate functions
 2. **Add error boundaries**: Wrap network calls and file operations with proper error handling  
 3. **Extract constants**: Move magic numbers to configuration or constants file
-4. **Fix typo**: Rename `centerLatidude` to `centerLatitude`
+4. ~~**Fix typo**: Rename `centerLatidude` to `centerLatitude`~~ ✅ Fixed
 5. **Cache WMS data**: Move aerial view download outside render loop
 6. **Add input validation**: Validate coordinates and bounds in transformation functions
 

--- a/src/main/kotlin/pixels/PixelsCalculation.kt
+++ b/src/main/kotlin/pixels/PixelsCalculation.kt
@@ -118,7 +118,7 @@ fun transformToPixelCoordinates(
         height = (bottom - top) * scale,
         scale = scale,
         aspectRatio = aspectRatio,
-        centerLatidude = centerLatitude,
+        centerLatitude = centerLatitude,
         centerLongitude = centerLongitude
     )
 }
@@ -139,6 +139,6 @@ class PixelsTransformation(
     val height: Double,
     val scale: Double = 1.0,
     val aspectRatio: Double = width / height,
-    val centerLatidude: Double = 0.0,
+    val centerLatitude: Double = 0.0,
     val centerLongitude: Double = 0.0
 )


### PR DESCRIPTION
- Fixed misspelled property name in PixelsTransformation data class
- Updated property usage in transformToPixelCoordinates function
- Updated review.md to mark issue as resolved

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)